### PR TITLE
Fixed support for Laravel Package Discovery

### DIFF
--- a/src/Classes/Package.php
+++ b/src/Classes/Package.php
@@ -46,8 +46,10 @@ class Package
                 ]
             ],
             'extra' => [
-                'providers' => [
-                    $this->namespace . '\\' . ucfirst(explode('/', $this->name)[1]) . 'ServiceProvider'
+                'laravel' =>[
+                    'providers' => [
+                        $this->namespace . '\\' . ucfirst(explode('/', $this->name)[1]) . 'ServiceProvider'
+                    ]
                 ]
             ],
             'minimum-stability' => "dev",


### PR DESCRIPTION
Providers must be declared within the 'laravel' array for auto discovery by Laravel